### PR TITLE
Update commenter to cat version

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -10,14 +10,14 @@ from cat.mad_hatter.decorators import hook
 
 
 @hook(priority=1)
-def agent_prompt_prefix(cat) -> str:
+def agent_prompt_prefix(prefix, cat) -> str:
     prefix = ""
 
     return prefix
 
 
 @hook(priority=1)
-def agent_prompt_suffix(cat) -> str:
+def agent_prompt_suffix(suffix, cat) -> str:
     using_vs_ext = "task" in cat.working_memory
 
     if using_vs_ext:
@@ -64,7 +64,8 @@ def agent_prompt_suffix(cat) -> str:
 
     return suffix
 
-
+"""
+#Temporarily commented out because the new version don't use this anymore
 @hook(priority=1)
 def agent_prompt_chat_history(chat_history: List[Dict], cat) -> str:
     history = ""
@@ -73,3 +74,5 @@ def agent_prompt_chat_history(chat_history: List[Dict], cat) -> str:
             history += f"\n - {turn['who']}: {turn['message']}"
 
     return history
+
+"""

--- a/prompt.py
+++ b/prompt.py
@@ -10,14 +10,14 @@ from cat.mad_hatter.decorators import hook
 
 
 @hook(priority=1)
-def agent_prompt_prefix(cat) -> str:
+def agent_prompt_prefix(prefix, cat) -> str:
     prefix = ""
 
     return prefix
 
 
 @hook(priority=1)
-def agent_prompt_suffix(cat) -> str:
+def agent_prompt_suffix(suffix, cat) -> str:
     using_vs_ext = "task" in cat.working_memory
 
     if using_vs_ext:
@@ -64,12 +64,12 @@ def agent_prompt_suffix(cat) -> str:
 
     return suffix
 
+# Temporarily commented out because the new version don't use this anymore
+# @hook(priority=1)
+# def agent_prompt_chat_history(chat_history: List[Dict], cat) -> str:
+#     history = ""
+#     if "task" not in cat.working_memory:
+#         for turn in chat_history:
+#             history += f"\n - {turn['who']}: {turn['message']}"
 
-@hook(priority=1)
-def agent_prompt_chat_history(chat_history: List[Dict], cat) -> str:
-    history = ""
-    if "task" not in cat.working_memory:
-        for turn in chat_history:
-            history += f"\n - {turn['who']}: {turn['message']}"
-
-    return history
+#     return history


### PR DESCRIPTION
hi! :)
I tried to update the two signatures as you said, and comment out the last one. And I think you were right about the fact that this seems to be not enough to be back in business :( 
I tried to test the plugin uploading it as a zip file in the plugin tab and I get this error in the last two lines of the console output:

```
INFO:     Application startup complete.
INFO:     172.17.0.1:64200 - "GET /admin HTTP/1.1" 307 Temporary Redirect
INFO:     172.17.0.1:64200 - "GET /admin/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64212 - "GET /assets/Rubik-BoldItalic.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64230 - "GET /assets/Rubik-MediumItalic.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64248 - "GET /assets/cat.css HTTP/1.1" 200 OK
INFO:     172.17.0.1:64200 - "GET /assets/Rubik-Bold.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64220 - "GET /assets/Rubik-Italic.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64240 - "GET /assets/Rubik-Medium.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64230 - "GET /assets/Rubik-Regular.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64220 - "GET /assets/Rubik-SemiBold.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64240 - "GET /assets/Rubik-SemiBoldItalic.ttf HTTP/1.1" 200 OK
INFO:     172.17.0.1:64212 - "GET /assets/cat.js HTTP/1.1" 200 OK
INFO:     ('172.17.0.1', 64260) - "WebSocket /ws/user" [accepted]
INFO:     connection open
INFO:     172.17.0.1:64212 - "GET /assets/logo.svg HTTP/1.1" 304 Not Modified
INFO:     172.17.0.1:64248 - "GET /memory/collections/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64240 - "GET /plugins/settings/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64200 - "GET / HTTP/1.1" 200 OK
INFO:     172.17.0.1:64220 - "GET /plugins/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64248 - "GET /memory/conversation_history/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64230 - "GET /llm/settings/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64212 - "GET /embedder/settings/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:64220 - "GET /admin/favicon.ico HTTP/1.1" 200 OK
INFO:     172.17.0.1:64220 - "GET /admin/favicon.ico HTTP/1.1" 200 OK
INFO:     172.17.0.1:56420 - "PUT /llm/settings/LLMOpenAIChatConfig/ HTTP/1.1" 307 Temporary Redirect
[2024-01-06 18:51:11.388] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::75 => 'Collection "episodic" has different embedder'
[2024-01-06 18:51:11.405] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::84 => 'Collection "episodic" deleted'
[2024-01-06 18:51:11.424] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.create_collection::103 => 'Creating collection episodic ...'
[2024-01-06 18:51:11.510] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::75 => 'Collection "declarative" has different embedder'
[2024-01-06 18:51:11.522] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::84 => 'Collection "declarative" deleted'
[2024-01-06 18:51:11.533] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.create_collection::103 => 'Creating collection declarative ...'
[2024-01-06 18:51:11.594] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::75 => 'Collection "procedural" has different embedder'
[2024-01-06 18:51:11.608] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.check_embedding_size::84 => 'Collection "procedural" deleted'
[2024-01-06 18:51:11.619] WARNING cat.memory.vector_memory_collection.VectorMemoryCollection.create_collection::103 => 'Creating collection procedural ...'
[2024-01-06 18:51:12.015] WARNING cat.looking_glass.cheshire_cat.CheshireCat.embed_tools::266 => ('Newly embedded tool: get_the_time(tool_input) - Replies to "what time is '
[2024-01-06 18:51:12.016] WARNING cat.looking_glass.cheshire_cat.CheshireCat.embed_tools::266 => 'it", "get the clock" and similar questions. Input is always None.')
INFO:     172.17.0.1:56420 - "PUT /llm/settings/LLMOpenAIChatConfig HTTP/1.1" 200 OK
INFO:     172.17.0.1:61016 - "PUT /embedder/settings/EmbedderOpenAIConfig/ HTTP/1.1" 307 Temporary Redirect
INFO:     172.17.0.1:61016 - "PUT /embedder/settings/EmbedderOpenAIConfig HTTP/1.1" 200 OK
INFO:     172.17.0.1:61016 - "GET /admin/favicon.ico HTTP/1.1" 200 OK
INFO:     172.17.0.1:61016 - "GET /admin/undefined HTTP/1.1" 200 OK
[2024-01-06 18:51:34.201] WARNING cat.mad_hatter.mad_hatter.MadHatter.toggle_plugin::196 => 'Toggle plugin ccat_code_commenter: Activate'
INFO:     172.17.0.1:57418 - "POST /plugins/upload/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:57418 - "GET /plugins/settings/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:57418 - "GET /plugins/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:57418 - "GET /admin/undefined HTTP/1.1" 200 OK
INFO:     ('172.17.0.1', 65006) - "WebSocket /ws" [accepted]
INFO:     connection open
INFO:     172.17.0.1:64990 - "GET /plugins/ HTTP/1.1" 200 OK
INFO:     172.17.0.1:65016 - "GET /settings/llm/ HTTP/1.1" 307 Temporary Redirect
INFO:     172.17.0.1:65030 - "GET /settings/llm HTTP/1.1" 404 Not Found

```
then when in VScode I try to do `right-click` `comment code` it doesn't work.
The Cat alone works as usual.

I may not be able to dive into the codebase on my own in the next few days (I am very new to the Cheshire-Cat in general as I said) to try to figure out what the problem might be, but if you have a way to provide me with some more insight, I'd like to try to spend some more time looking into this topic.